### PR TITLE
Match line-only suffix in file path regex

### DIFF
--- a/scripts/awk_pane_files.sh
+++ b/scripts/awk_pane_files.sh
@@ -8,7 +8,7 @@ parse_files() {
   LC_ALL=C awk '
   BEGIN { RS = "\n"; FS = ""; }
   {
-    while (match($0, /[^[:space:]"]*\/[[:alnum:]._-]+(\/[[:alnum:]._-]+)*\.[[:alnum:]]+(:[0-9]+:[0-9]+)?/)) {
+    while (match($0, /[^[:space:]"]*\/[[:alnum:]._-]+(\/[[:alnum:]._-]+)*\.[[:alnum:]]+(:[0-9]+(:[0-9]+)?)?/)) {
       path = substr($0, RSTART, RLENGTH)
       if (!seen[path]++) {
         print path

--- a/tests/awk_pane_files.bats
+++ b/tests/awk_pane_files.bats
@@ -27,6 +27,49 @@ source "$BATS_TEST_DIRNAME/../scripts/awk_pane_files.sh"
   [ "$result" = "something/somethingelse.txt" ]
 }
 
+@test "parse_files matches grep-style line-only suffix" {
+  result="$(echo "src/utils/parser.go:42:found a match" | parse_files)"
+  [ "$result" = "src/utils/parser.go:42" ]
+}
+
+@test "parse_files matches ripgrep output with line-only suffix" {
+  result="$(echo "path/to/file.rs:128:    let x = 1;" | parse_files)"
+  [ "$result" = "path/to/file.rs:128" ]
+}
+
+@test "parse_files still matches line:col compiler error suffix" {
+  result="$(echo "error: src/main.c:42:5: undeclared identifier" | parse_files)"
+  [ "$result" = "src/main.c:42:5" ]
+}
+
+@test "parse_files matches mypy-style line-only error output" {
+  result="$(echo "app/models/user.py:17: error: Incompatible return value" | parse_files)"
+  [ "$result" = "app/models/user.py:17" ]
+}
+
+@test "parse_files matches make-style line-only error output" {
+  result="$(echo "build/Makefile.in:10: *** missing separator." | parse_files)"
+  [ "$result" = "build/Makefile.in:10" ]
+}
+
+@test "parse_files matches js stack trace with line-only suffix" {
+  result="$(echo "    at processTicks /usr/lib/node_modules/foo/index.js:95" | parse_files)"
+  [ "$result" = "/usr/lib/node_modules/foo/index.js:95" ]
+}
+
+@test "parse_files matches multiple files with mixed suffix styles" {
+  result="$(echo "a/b/one.ts:10 a/b/two.ts:20:5 a/b/three.ts" | parse_files)"
+  expected="a/b/one.ts:10
+a/b/two.ts:20:5
+a/b/three.ts"
+  [ "$result" = "$expected" ]
+}
+
+@test "parse_files does not consume trailing non-numeric text as line suffix" {
+  result="$(echo "lib/foo.js:abc" | parse_files)"
+  [ "$result" = "lib/foo.js" ]
+}
+
 @test "remove invalid characters" {
   result="$(echo "(&&here/is-dashes-in-name/a/file.txt)" | remove_invalid_characters)"
   [ "$result" = "here/is-dashes-in-name/a/file.txt" ]


### PR DESCRIPTION
## Summary
- Made the column number optional in the file path suffix regex in `scripts/awk_pane_files.sh` so `path:line` is captured in addition to `path` and `path:line:col`.
- Added 8 bats tests covering grep/ripgrep, mypy, make, node stack frame patterns, mixed-suffix multi-file input, and the negative case where trailing non-numeric text isn't consumed.

## Why
Many common tools emit `path:line` rather than `path:line:col`: grep -n, ripgrep, mypy, make, and node stack frames. The previous regex required both line and column together, so these line references were stripped and the file was opened without cursor positioning.

## Test plan
- [x] `bats tests/awk_pane_files.bats` — 14/14 passing
- [x] `bats tests` — full suite 27/27 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)