### PR TITLE
Add tmux popup integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,20 @@
+name: Run integration tests
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
+
+      - name: Run integration test
+        run: bash tests/integration/run.sh

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# End-to-end check that fzf-files.sh, given file paths visible in a real tmux
+# pane, extracts them, opens the popup, lets fzf select one, and prints it.
+#
+# How it works:
+#   * Starts a detached tmux server on a private socket.
+#   * Echoes file-path-shaped strings into the pane so capture-pane sees them.
+#   * Runs utilities/fzf-files.sh inside that pane, but inside a wrapper that:
+#       - puts a stub `fzf` (picks the first line) on PATH, and
+#       - overrides the `tmux` shell function so that `display-popup -E "<cmd>"`
+#         runs <cmd> directly. All other tmux calls still hit the real server.
+#   * Asserts that the popup wrapper was invoked AND the script printed the
+#     first matching file path.
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKDIR="$(mktemp -d -t tfof-int-XXXXXX)"
+SOCKET="tfof-int-$$"
+SESSION="test"
+PASS=0
+FAIL=0
+
+cleanup() {
+  tmux -L "$SOCKET" kill-server 2>/dev/null || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# --- Stub fzf: ignores flags, prints the first non-empty line of stdin. ---
+cat >"$WORKDIR/fzf" <<'STUB'
+#!/usr/bin/env bash
+awk 'NF { print; exit }'
+STUB
+chmod +x "$WORKDIR/fzf"
+
+# --- Runner: bypasses display-popup rendering, runs the inner command. ---
+cat >"$WORKDIR/runner.sh" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmux() {
+  if [[ "\$1" == "display-popup" ]]; then
+    touch "$WORKDIR/popup_invoked"
+    local cmd="" found=0
+    for arg in "\$@"; do
+      if [[ \$found -eq 1 ]]; then
+        cmd="\$arg"
+        break
+      fi
+      [[ "\$arg" == "-E" ]] && found=1
+    done
+    eval "\$cmd"
+    return \$?
+  fi
+  command tmux "\$@"
+}
+export -f tmux
+
+PATH="$WORKDIR:\$PATH" bash "$PLUGIN_DIR/utilities/fzf-files.sh" "\${1:-}"
+RUNNER
+chmod +x "$WORKDIR/runner.sh"
+
+run_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local arg="${1:-}"
+
+  rm -f "$WORKDIR/out" "$WORKDIR/done" "$WORKDIR/popup_invoked"
+
+  tmux -L "$SOCKET" send-keys -t "$SESSION" "clear" Enter
+  sleep 0.2
+  tmux -L "$SOCKET" send-keys -t "$SESSION" "echo scripts/awk_pane_files.sh" Enter
+  tmux -L "$SOCKET" send-keys -t "$SESSION" "echo src/utils/parser.go:42" Enter
+  tmux -L "$SOCKET" send-keys -t "$SESSION" "echo tests/awk_pane_files.bats" Enter
+  sleep 0.3
+
+  tmux -L "$SOCKET" send-keys -t "$SESSION" \
+    "bash '$WORKDIR/runner.sh' $arg >'$WORKDIR/out' 2>&1; touch '$WORKDIR/done'" Enter
+
+  for _ in $(seq 1 40); do
+    [ -f "$WORKDIR/done" ] && break
+    sleep 0.25
+  done
+
+  if [ ! -f "$WORKDIR/done" ]; then
+    echo "[FAIL] $name: runner did not complete within 10s"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local result
+  result="$(cat "$WORKDIR/out")"
+
+  if [ ! -f "$WORKDIR/popup_invoked" ]; then
+    echo "[FAIL] $name: display-popup was never invoked"
+    echo "       output: $result"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [[ "$result" != "$expected" ]]; then
+    echo "[FAIL] $name"
+    echo "       expected: $expected"
+    echo "       got:      $result"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  echo "[PASS] $name"
+  PASS=$((PASS + 1))
+}
+
+tmux -L "$SOCKET" new-session -d -s "$SESSION" -x 200 -y 50
+
+run_case "visible pane (default)" "scripts/awk_pane_files.sh"
+run_case "selected pane history"  "scripts/awk_pane_files.sh" "--selected-pane-history"
+run_case "all pane history"       "scripts/awk_pane_files.sh" "--all-pane-history"
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -34,37 +34,29 @@ STUB
 chmod +x "$WORKDIR/fzf"
 
 # --- Runner: bypasses display-popup rendering, runs the inner command. ---
-cat >"$WORKDIR/runner.sh" <<RUNNER
-#!/usr/bin/env bash
+{
+  printf '#!/usr/bin/env bash\nexport WORKDIR=%q PLUGIN_DIR=%q\n' "$WORKDIR" "$PLUGIN_DIR"
+  cat <<'RUNNER'
 set -euo pipefail
 
 tmux() {
-  if [[ "\$1" == "display-popup" ]]; then
+  if [[ "$1" == "display-popup" ]]; then
     touch "$WORKDIR/popup_invoked"
-    local cmd="" found=0
-    for arg in "\$@"; do
-      if [[ \$found -eq 1 ]]; then
-        cmd="\$arg"
-        break
-      fi
-      [[ "\$arg" == "-E" ]] && found=1
-    done
-    eval "\$cmd"
-    return \$?
+    [[ "${*: -2:1}" == "-E" ]] || { echo "popup wrapper: expected -E before command" >&2; return 1; }
+    eval "${*: -1}"
+    return
   fi
-  command tmux "\$@"
+  command tmux "$@"
 }
 export -f tmux
 
-PATH="$WORKDIR:\$PATH" bash "$PLUGIN_DIR/utilities/fzf-files.sh" "\${1:-}"
+PATH="$WORKDIR:$PATH" bash "$PLUGIN_DIR/utilities/fzf-files.sh" "${1:-}"
 RUNNER
+} >"$WORKDIR/runner.sh"
 chmod +x "$WORKDIR/runner.sh"
 
 run_case() {
-  local name="$1"
-  local expected="$2"
-  shift 2
-  local arg="${1:-}"
+  local name="$1" expected="$2" arg="${3:-}"
 
   rm -f "$WORKDIR/out" "$WORKDIR/done" "$WORKDIR/popup_invoked"
 
@@ -83,32 +75,21 @@ run_case() {
     sleep 0.25
   done
 
-  if [ ! -f "$WORKDIR/done" ]; then
-    echo "[FAIL] $name: runner did not complete within 10s"
-    FAIL=$((FAIL + 1))
-    return
-  fi
-
   local result
-  result="$(cat "$WORKDIR/out")"
+  result="$(cat "$WORKDIR/out" 2>/dev/null || true)"
 
-  if [ ! -f "$WORKDIR/popup_invoked" ]; then
-    echo "[FAIL] $name: display-popup was never invoked"
-    echo "       output: $result"
-    FAIL=$((FAIL + 1))
+  if [ -f "$WORKDIR/done" ] && [ -f "$WORKDIR/popup_invoked" ] && [[ "$result" == "$expected" ]]; then
+    echo "[PASS] $name"
+    PASS=$((PASS + 1))
     return
   fi
 
-  if [[ "$result" != "$expected" ]]; then
-    echo "[FAIL] $name"
-    echo "       expected: $expected"
-    echo "       got:      $result"
-    FAIL=$((FAIL + 1))
-    return
-  fi
-
-  echo "[PASS] $name"
-  PASS=$((PASS + 1))
+  echo "[FAIL] $name"
+  [ -f "$WORKDIR/done" ] || echo "       runner did not complete within 10s"
+  [ -f "$WORKDIR/popup_invoked" ] || echo "       display-popup was never invoked"
+  echo "       expected: $expected"
+  echo "       got:      $result"
+  FAIL=$((FAIL + 1))
 }
 
 tmux -L "$SOCKET" new-session -d -s "$SESSION" -x 200 -y 50

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -114,8 +114,8 @@ run_case() {
 tmux -L "$SOCKET" new-session -d -s "$SESSION" -x 200 -y 50
 
 run_case "visible pane (default)" "scripts/awk_pane_files.sh"
-run_case "selected pane history"  "scripts/awk_pane_files.sh" "--selected-pane-history"
-run_case "all pane history"       "scripts/awk_pane_files.sh" "--all-pane-history"
+run_case "selected pane history" "scripts/awk_pane_files.sh" "--selected-pane-history"
+run_case "all pane history" "scripts/awk_pane_files.sh" "--all-pane-history"
 
 echo
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Adds an end-to-end integration test that exercises the full `capture-pane → parse_files → display-popup → fzf → return` flow on a real tmux server. Runnable locally (`bash tests/integration/run.sh`) and in a new `Run integration tests` GitHub workflow.

The test stubs `fzf` (auto-selects the first line) and overrides only `tmux display-popup -E "<cmd>"` to run `<cmd>` directly — every other tmux call hits the real server. Each case asserts both that the popup wrapper was invoked and that the script printed the expected file path. Three cases cover the visible-pane default, `--selected-pane-history`, and `--all-pane-history`.

Note: this PR also includes the prior `expand-file-regex-line-suffix` commit (`349cdee`), since this branch was forked from it before it was merged.

## Keybindings

No changes.

## Related Issues

None.

## Screenshots or Video

```
$ bash tests/integration/run.sh
[PASS] visible pane (default)
[PASS] selected pane history
[PASS] all pane history

3 passed, 0 failed
```