### PR TITLE
Pick nearest nvim instance when searching across windows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,8 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux and neovim
+        run: sudo apt-get update && sudo apt-get install -y tmux neovim
 
       - name: Run integration test
         run: bash tests/integration/run.sh
+
+      - name: Run nearest-nvim integration test
+        run: bash tests/integration/nearest_nvim.sh

--- a/scripts/tmux_find_nvim_target.sh
+++ b/scripts/tmux_find_nvim_target.sh
@@ -33,10 +33,17 @@ find_nvim_target() {
   search_across_windows=$(tmux show-option -gqv @tmux-open-file-nvim-search-all-windows)
 
   if [[ "$search_across_windows" == "on" ]]; then
-    # search across all windows in current session
+    # search across all windows in current session, picking the nearest by window index
     current_session=$(tmux display-message -p '#S')
-    pane_info=$(tmux list-panes -a -F '#{session_name} #{window_id} #{pane_id} #{pane_current_command}' | grep "^$current_session " | grep "nvim" | head -1)
-    extract_pane_info "$pane_info" 2 3
+    current_window_index=$(tmux display-message -p '#I')
+    tmux list-panes -a -F '#{session_name} #{window_index} #{window_id} #{pane_id} #{pane_current_command}' \
+      | awk -v sess="$current_session" -v cur="$current_window_index" '
+          $1 == sess && $5 == "nvim" {
+            d = $2 - cur; if (d < 0) d = -d
+            if (best == "" || d < best_d) { best_d = d; best = $3 " " $4 }
+          }
+          END { if (best != "") print best }
+        '
   else
     # search only in current window
     pane_info=$(tmux list-panes -F '#{window_id} #{pane_id} #{pane_current_command}' | grep "nvim" | head -1)

--- a/scripts/tmux_find_nvim_target.sh
+++ b/scripts/tmux_find_nvim_target.sh
@@ -36,8 +36,8 @@ find_nvim_target() {
     # search across all windows in current session, picking the nearest by window index
     current_session=$(tmux display-message -p '#S')
     current_window_index=$(tmux display-message -p '#I')
-    tmux list-panes -a -F '#{session_name} #{window_index} #{window_id} #{pane_id} #{pane_current_command}' \
-      | awk -v sess="$current_session" -v cur="$current_window_index" '
+    tmux list-panes -a -F '#{session_name} #{window_index} #{window_id} #{pane_id} #{pane_current_command}' |
+      awk -v sess="$current_session" -v cur="$current_window_index" '
           $1 == sess && $5 == "nvim" {
             d = $2 - cur; if (d < 0) d = -d
             if (best == "" || d < best_d) { best_d = d; best = $3 " " $4 }

--- a/tests/integration/nearest_nvim.sh
+++ b/tests/integration/nearest_nvim.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# End-to-end check that find_nvim_target picks the nvim instance whose
+# window index is closest to the current window when search-all-windows
+# is enabled.
+#
+# How it works:
+#   * Starts a detached tmux server on a private socket with five windows.
+#   * Launches a real `nvim` in a configurable subset of those windows
+#     and waits for tmux to report `pane_current_command == nvim`.
+#   * Selects a "current" window, then sources the plugin's helper and
+#     invokes find_nvim_target with a stubbed show-option (so the helper
+#     thinks @tmux-open-file-nvim-search-all-windows is "on") and a tmux
+#     wrapper that forwards every other call to the private socket.
+#   * Translates the returned `@<wid> %<pid>` back to a window index and
+#     asserts it matches the expected nearest window.
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOCKET="tfof-nearest-$$"
+SESSION="t"
+PASS=0
+FAIL=0
+
+cleanup() {
+  tmux -L "$SOCKET" kill-server 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_cmd() {
+  local target_pane="$1" want="$2" got=""
+  for _ in $(seq 1 80); do
+    got=$(tmux -L "$SOCKET" display-message -p -t "$target_pane" '#{pane_current_command}')
+    [[ "$got" == "$want" ]] && return 0
+    sleep 0.1
+  done
+  echo "  timed out waiting for $target_pane to be running '$want' (last: '$got')" >&2
+  return 1
+}
+
+# run_case <name> <current-window-idx> <expected-window-idx> <nvim-window-idx>...
+run_case() {
+  local name="$1" current_idx="$2" expected_idx="$3"
+  shift 3
+  local nvim_windows=("$@")
+
+  tmux -L "$SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
+  tmux -L "$SOCKET" new-session -d -s "$SESSION" -x 200 -y 50
+
+  for i in 1 2 3 4; do
+    tmux -L "$SOCKET" new-window -t "$SESSION:$i"
+  done
+
+  local w pane_id
+  for w in "${nvim_windows[@]}"; do
+    tmux -L "$SOCKET" send-keys -t "$SESSION:$w" "nvim --clean -n" Enter
+    pane_id=$(tmux -L "$SOCKET" display-message -p -t "$SESSION:$w" '#{pane_id}')
+    if ! wait_for_cmd "$pane_id" "nvim"; then
+      echo "[FAIL] $name (nvim never started in window $w)"
+      FAIL=$((FAIL + 1))
+      return
+    fi
+  done
+
+  tmux -L "$SOCKET" select-window -t "$SESSION:$current_idx"
+
+  local result
+  result=$(
+    export PLUGIN_DIR SOCKET
+    bash -c '
+      source "$PLUGIN_DIR/scripts/tmux_find_nvim_target.sh"
+      tmux() {
+        if [[ "$1 $2 $3" == "show-option -gqv @tmux-open-file-nvim-search-all-windows" ]]; then
+          echo "on"
+          return
+        fi
+        command tmux -L "$SOCKET" "$@"
+      }
+      find_nvim_target
+    '
+  )
+
+  local picked_wid picked_pid picked_idx
+  read -r picked_wid picked_pid <<<"$result"
+  if [[ -z "$picked_wid" ]]; then
+    picked_idx="(none)"
+  else
+    picked_idx=$(tmux -L "$SOCKET" display-message -p -t "$picked_wid" '#{window_index}' 2>/dev/null || echo "?")
+  fi
+
+  if [[ "$picked_idx" == "$expected_idx" ]]; then
+    echo "[PASS] $name  (current=$current_idx, nvim in {${nvim_windows[*]}}, picked window $picked_idx)"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] $name  (current=$current_idx, nvim in {${nvim_windows[*]}})"
+    echo "       expected window: $expected_idx"
+    echo "       got window:      $picked_idx   (raw: '$result')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Args: name, current-window, expected-window, nvim-windows...
+run_case "nearest is to the right" 3 4 0 4
+run_case "nearest is to the left" 1 0 0 4
+run_case "current window wins (distance 0)" 1 1 0 1 4
+run_case "single nvim far away is still picked" 0 4 4
+run_case "three candidates, middle is closest" 2 3 0 3 4
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/mock_tmux.sh
+++ b/tests/mock_tmux.sh
@@ -14,15 +14,18 @@ handle_tmux_command() {
       echo "@0 %2 bash"
       echo "@0 %3 nvim"
       ;;
-    "list-panes -a -F #{session_name} #{window_id} #{pane_id} #{pane_current_command}")
-      echo "test_session @0 %1 nvim"
-      echo "test_session @0 %2 bash"
-      echo "test_session @0 %3 nvim"
-      echo "test_session @1 %4 bash"
-      echo "test_session @1 %5 nvim"
+    "list-panes -a -F #{session_name} #{window_index} #{window_id} #{pane_id} #{pane_current_command}")
+      echo "test_session 1 @0 %1 nvim"
+      echo "test_session 1 @0 %2 bash"
+      echo "test_session 1 @0 %3 nvim"
+      echo "test_session 2 @1 %4 bash"
+      echo "test_session 2 @1 %5 nvim"
       ;;
     "display-message -p #S")
       echo "test_session"
+      ;;
+    "display-message -p #I")
+      echo "1"
       ;;
     "send-keys -t %1 :echo 'Hello from tmux!' Enter")
       echo "Command sent to Neovim pane"

--- a/tests/nvim_pane.bats
+++ b/tests/nvim_pane.bats
@@ -27,11 +27,14 @@ teardown() {
       "display-message -p #S")
         echo "test_session"
         ;;
-      "list-panes -a -F #{session_name} #{window_id} #{pane_id} #{pane_current_command}")
-        echo "test_session @0 %1 bash"
-        echo "test_session @0 %2 bash"
-        echo "test_session @1 %3 bash"
-        echo "test_session @1 %4 nvim"
+      "display-message -p #I")
+        echo "1"
+        ;;
+      "list-panes -a -F #{session_name} #{window_index} #{window_id} #{pane_id} #{pane_current_command}")
+        echo "test_session 1 @0 %1 bash"
+        echo "test_session 1 @0 %2 bash"
+        echo "test_session 2 @1 %3 bash"
+        echo "test_session 2 @1 %4 nvim"
         ;;
       "show-option -gqv @tmux-open-file-nvim-search-all-windows")
         echo "on"
@@ -45,6 +48,69 @@ teardown() {
 
   result="$(find_nvim_target)"
   [ "$result" = "@1 %4" ]
+}
+
+@test "should pick the nearest nvim instance when multiple exist across windows" {
+  export TMUX_OPTION_tmux_open_file_nvim_search_all_windows="on"
+
+  # Current window is index 5; nvim exists in windows 1, 4, and 8 — window 4 is nearest
+  tmux() {
+    case "$*" in
+      "display-message -p #S")
+        echo "test_session"
+        ;;
+      "display-message -p #I")
+        echo "5"
+        ;;
+      "list-panes -a -F #{session_name} #{window_index} #{window_id} #{pane_id} #{pane_current_command}")
+        echo "test_session 1 @0 %1 nvim"
+        echo "test_session 4 @1 %2 nvim"
+        echo "test_session 5 @2 %3 bash"
+        echo "test_session 8 @3 %4 nvim"
+        ;;
+      "show-option -gqv @tmux-open-file-nvim-search-all-windows")
+        echo "on"
+        ;;
+      *)
+        echo "Unknown tmux command: $*" >&2
+        exit 1
+        ;;
+    esac
+  }
+
+  result="$(find_nvim_target)"
+  [ "$result" = "@1 %2" ]
+}
+
+@test "should prefer nvim in the current window over nvim in other windows" {
+  export TMUX_OPTION_tmux_open_file_nvim_search_all_windows="on"
+
+  tmux() {
+    case "$*" in
+      "display-message -p #S")
+        echo "test_session"
+        ;;
+      "display-message -p #I")
+        echo "3"
+        ;;
+      "list-panes -a -F #{session_name} #{window_index} #{window_id} #{pane_id} #{pane_current_command}")
+        echo "test_session 1 @0 %1 nvim"
+        echo "test_session 3 @1 %2 bash"
+        echo "test_session 3 @1 %3 nvim"
+        echo "test_session 4 @2 %4 nvim"
+        ;;
+      "show-option -gqv @tmux-open-file-nvim-search-all-windows")
+        echo "on"
+        ;;
+      *)
+        echo "Unknown tmux command: $*" >&2
+        exit 1
+        ;;
+    esac
+  }
+
+  result="$(find_nvim_target)"
+  [ "$result" = "@1 %3" ]
 }
 
 @test "should not find nvim in different window when search-all-windows is off" {


### PR DESCRIPTION
## Summary
- When `@tmux-open-file-nvim-search-all-windows` is `on`, the plugin used to pick the first nvim pane returned by `tmux list-panes -a`, which could land on a window far from the user's current one.
- The cross-window search now ranks nvim panes by absolute distance between their `window_index` and the current window's index, so the nearest nvim is chosen (and an nvim in the current window wins with distance 0).

## Test plan
- [x] `bats tests/*.bats` — 29/29 passing, including two new cases in `tests/nvim_pane.bats` covering nearest-of-three selection and current-window preference.
- [x] Manual smoke test in a real tmux session with nvim open in multiple distant windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)